### PR TITLE
購入画面修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -5,9 +5,6 @@ class ItemsController < ApplicationController
   def index
   end
 
-  def new
-  end
-
   def show
     @comment = Comment.new
     @comments = @item.comments.includes(:user)
@@ -71,25 +68,29 @@ class ItemsController < ApplicationController
   end
 
   def purchase
-    
-    @item = Item.find(params[:item_id])
+    @item = Item.find(params[:id])
     
     Payjp.api_key = ENV['PAYJP_TEST_SECRET_KEY']
     begin
-      Payjp::Charge.create(currency: 'jpy', amount: 100, card: params['payjp-token'])
+      Payjp::Charge.create(currency: 'jpy', amount: @item.price, card: params['payjp-token'])
     rescue
-      redirect_to items_path
+      redirect_to confirm_item_path(@item)
     end
     
     @item.update(buyer_id: current_user.id, selled_at: "#{DateTime.now}", )
 
-    @status = OrderStatus.find(params[:item_id])
+    @status = OrderStatus.find(params[:id])
     
     @status.update(status: 3)
-    redirect_to '/items/complete' #このパスは仮置き
+    redirect_to complete_item_path(@item)
+  end
+
+  def confirm
+    @item = Item.find(params[:id])
   end
 
   def complete
+    @item = Item.find(params[:id])
   end
 
   def search

--- a/app/controllers/tops_controller.rb
+++ b/app/controllers/tops_controller.rb
@@ -14,4 +14,5 @@ class TopsController < ApplicationController
   def edit
     @user = User.find(current_user)
   end
+  
 end

--- a/app/views/items/complete.html.haml
+++ b/app/views/items/complete.html.haml
@@ -14,22 +14,26 @@
       購入が完了しました
   .buy-item-container
     .item-photo
-      = image_tag("m89940654731_1.jpg", class:"item-photo") 
+      = image_tag(@item.item_images.first.image.url, class:"item-photo") 
     .item-name
-      VIS LEE コラボホワイトデニム M
+      = @item.name
   .buy-item-price-container
     .buy-item-price
-      ¥6,200
+      #{number_to_currency(@item.price, :unit => "¥ ", :precision => 0)}
     .buy-item-tax
       送料込み
   .shipping-address-container
     .shipping-address-head
       配送先
     .shipping-address
-      〒111-1111
-      神奈川県横浜市中央区1-1-1
+      = @item.user.address.zip
+      = @item.user.address.prefectures
+      = @item.user.address.city
+      = @item.user.address.block
+      = @item.user.address.building
     .shipping-name
-      山田 花子
+      = @item.user.address.last_name
+      = @item.user.address.first_name
   .method-of-payment-container
     .method-of-payment-head
       支払い方法

--- a/app/views/items/confirm.html.haml
+++ b/app/views/items/confirm.html.haml
@@ -7,29 +7,35 @@
       購入内容の確認
   .buy-item-container
     .item-photo
-      = image_tag("m89940654731_1.jpg", class:"item-photo") 
+      = image_tag(@item.item_images.first.image.url, class:"item-photo") 
     .item-name
-      VIS LEE コラボホワイトデニム M
+      = @item.name
   .buy-item-price-container
     .buy-item-price
-      ¥6,200
+      #{number_to_currency(@item.price, :unit => "¥ ", :precision => 0)}
     .buy-item-tax
-      送料込み
+      = @item.delivery_cost
   .pay-price-container
     .pay-price-title
       支払い金額
     .pay-price
-      ¥ 6,200
-  = form_tag(action: :purchase, method: :post) do
+      #{number_to_currency(@item.price, :unit => "¥ ", :precision => 0)}
+  = form_tag(action: :purchase, controller: :items, url: complete_item_path(@item), method: :post) do
     %script.payjp-button{"data-key": ENV['PAYJP_TEST_PUBLIC_KEY'], src: "https://checkout.pay.jp", type: "text/javascript", "data-text": "購入する"}
   .shipping-address-container
     .shipping-address-head
       配送先
     .shipping-address
-      〒111-1111
-      神奈川県横浜市中央区1-1-1
+      = @item.user.address.zip
+      = @item.user.address.prefectures
+      = @item.user.address.city
+      = @item.user.address.block
+      = @item.user.address.building
+
     .shipping-name
-      山田 花子
+      = @item.user.address.last_name
+      = @item.user.address.first_name
+      
     .change-button
       .p 変更する >
   .method-of-payment-container

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -103,7 +103,7 @@
         - unless @item.sales_condition
           - if user_signed_in?
             .buy-button
-              = link_to new_item_path do
+              = link_to confirm_item_path(@item) do
                 購入画面に進む
           - else
             .buy-button

--- a/app/views/tops/_main.html.haml
+++ b/app/views/tops/_main.html.haml
@@ -1,176 +1,176 @@
--# %section.main-banner
--#   = image_tag('main-banner.jpg', class: 'main-banner__image')
--# %section.category-items-box
--#   %h2.product-name
--#     ピックアップカテゴリー
--#   .product-container-ladys
--#     %h3.product-container-ladys__title
--#       = link_to 'レディース 新着アイテム', root_path, class: 'product-container-ladys__title__link-btn'
--#     .product-container-ladys__contents
--#       .product-container-ladys__contents__child__body
--#         - @ladysitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-ladys__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-ladys__contents__child__body__info
--#               .product-container-ladys__contents__child__body__info__name
--#                 =item.name
--#               .product-container-ladys__contents__child__body__info__2
--#                 .product-container-ladys__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-ladys__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
+%section.main-banner
+  = image_tag('main-banner.jpg', class: 'main-banner__image')
+%section.category-items-box
+  %h2.product-name
+    ピックアップカテゴリー
+  .product-container-ladys
+    %h3.product-container-ladys__title
+      = link_to 'レディース 新着アイテム', root_path, class: 'product-container-ladys__title__link-btn'
+    .product-container-ladys__contents
+      .product-container-ladys__contents__child__body
+        - @ladysitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-ladys__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-ladys__contents__child__body__info
+              .product-container-ladys__contents__child__body__info__name
+                =item.name
+              .product-container-ladys__contents__child__body__info__2
+                .product-container-ladys__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-ladys__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
 
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
 
--#   .product-container-mens
--#     %h3.product-container-mens__title
--#       = link_to 'メンズ 新着アイテム', root_path, class: 'product-container-mens__title__link-btn'
--#     .product-container-mens__contents
--#       .product-container-mens__contents__child__body
--#         - @mensitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-mens__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-mens__contents__child__body__info
--#               .product-container-mens__contents__child__body__info__name
--#                 =item.name
--#               .product-container-mens__contents__child__body__info__2
--#                 .product-container-mens__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-mens__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+  .product-container-mens
+    %h3.product-container-mens__title
+      = link_to 'メンズ 新着アイテム', root_path, class: 'product-container-mens__title__link-btn'
+    .product-container-mens__contents
+      .product-container-mens__contents__child__body
+        - @mensitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-mens__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-mens__contents__child__body__info
+              .product-container-mens__contents__child__body__info__name
+                =item.name
+              .product-container-mens__contents__child__body__info__2
+                .product-container-mens__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-mens__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
 
--#   .product-container-babykids
--#     %h3.product-container-babykids__title
--#       = link_to 'ベビー・キッズ 新着アイテム', root_path, class: 'product-container-babykids__title__link-btn'
--#     .product-container-babykids__contents
--#       .product-container-babykids__contents__child__body
--#         - @babykidsitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-babykids__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-babykids__contents__child__body__info
--#               .product-container-babykids__contents__child__body__info__name
--#                 =item.name
--#               .product-container-babykids__contents__child__body__info__2
--#                 .product-container-babykids__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-babykids__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+  .product-container-babykids
+    %h3.product-container-babykids__title
+      = link_to 'ベビー・キッズ 新着アイテム', root_path, class: 'product-container-babykids__title__link-btn'
+    .product-container-babykids__contents
+      .product-container-babykids__contents__child__body
+        - @babykidsitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-babykids__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-babykids__contents__child__body__info
+              .product-container-babykids__contents__child__body__info__name
+                =item.name
+              .product-container-babykids__contents__child__body__info__2
+                .product-container-babykids__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-babykids__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
     
--#   .product-container-cosme
--#     %h3.product-container-cosme__title
--#       = link_to 'コスメ・香水・美容 新着アイテム', root_path, class: 'product-container-cosme__title__link-btn'
--#     .product-container-cosme__contents
--#       .product-container-cosme__contents__child__body
--#         - @cosmeitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-cosme__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-cosme__contents__child__body__info
--#               .product-container-cosme__contents__child__body__info__name
--#                 =item.name
--#               .product-container-cosme__contents__child__body__info__2
--#                 .product-container-cosme__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-cosme__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+  .product-container-cosme
+    %h3.product-container-cosme__title
+      = link_to 'コスメ・香水・美容 新着アイテム', root_path, class: 'product-container-cosme__title__link-btn'
+    .product-container-cosme__contents
+      .product-container-cosme__contents__child__body
+        - @cosmeitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-cosme__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-cosme__contents__child__body__info
+              .product-container-cosme__contents__child__body__info__name
+                =item.name
+              .product-container-cosme__contents__child__body__info__2
+                .product-container-cosme__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-cosme__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
 
--# %section.brand-items-box
--#   %h2.product-name
--#     ピックアップブランド
--#   .product-container-zyaneru
--#     %h3.product-container-zyaneru__title
--#       = link_to 'ジャネル 新着アイテム', root_path, class: 'product-container-zyaneru__title__link-btn'
--#     .product-container-zyaneru__contents
--#       .product-container-zyaneru__contents__child__body
--#         - @zyaneruitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-zyaneru__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-zyaneru__contents__child__body__info
--#               .product-container-zyaneru__contents__child__body__info__name
--#                 =item.name
--#               .product-container-zyaneru__contents__child__body__info__2
--#                 .product-container-zyaneru__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-zyaneru__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+%section.brand-items-box
+  %h2.product-name
+    ピックアップブランド
+  .product-container-zyaneru
+    %h3.product-container-zyaneru__title
+      = link_to 'ジャネル 新着アイテム', root_path, class: 'product-container-zyaneru__title__link-btn'
+    .product-container-zyaneru__contents
+      .product-container-zyaneru__contents__child__body
+        - @zyaneruitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-zyaneru__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-zyaneru__contents__child__body__info
+              .product-container-zyaneru__contents__child__body__info__name
+                =item.name
+              .product-container-zyaneru__contents__child__body__info__2
+                .product-container-zyaneru__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-zyaneru__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
 
--#   .product-container-shufureem
--#     %h3.product-container-shufureem__title
--#       = link_to 'シュフリーム 新着アイテム', root_path, class: 'product-container-shufureem__title__link-btn'
--#     .product-container-shufureem__contents
--#       .product-container-shufureem__contents__child__body
--#         - @shufureemitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             %figure.product-container-shufureem__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-shufureem__contents__child__body__info
--#               .product-container-shufureem__contents__child__body__info__name
--#                 =item.name
--#               .product-container-shufureem__contents__child__body__info__2
--#                 .product-container-shufureem__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-shufureem__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+  .product-container-shufureem
+    %h3.product-container-shufureem__title
+      = link_to 'シュフリーム 新着アイテム', root_path, class: 'product-container-shufureem__title__link-btn'
+    .product-container-shufureem__contents
+      .product-container-shufureem__contents__child__body
+        - @shufureemitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            %figure.product-container-shufureem__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-shufureem__contents__child__body__info
+              .product-container-shufureem__contents__child__body__info__name
+                =item.name
+              .product-container-shufureem__contents__child__body__info__2
+                .product-container-shufureem__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-shufureem__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
   
--#   .product-container-ruiweton
--#     %h3.product-container-ruiweton__title
--#       = link_to 'ルイウィトン 新着アイテム', root_path, class: 'product-container-ruiweton__title__link-btn'
--#     .product-container-ruiweton__contents
--#       .product-container-ruiweton__contents__child__body
--#         - @ruiwetonitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-ruiweton__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-ruiweton__contents__child__body__info
--#               .product-container-ruiweton__contents__child__body__info__name
--#                 =item.name
--#               .product-container-ruiweton__contents__child__body__info__2
--#                 .product-container-ruiweton__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-ruiweton__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+  .product-container-ruiweton
+    %h3.product-container-ruiweton__title
+      = link_to 'ルイウィトン 新着アイテム', root_path, class: 'product-container-ruiweton__title__link-btn'
+    .product-container-ruiweton__contents
+      .product-container-ruiweton__contents__child__body
+        - @ruiwetonitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-ruiweton__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-ruiweton__contents__child__body__info
+              .product-container-ruiweton__contents__child__body__info__name
+                =item.name
+              .product-container-ruiweton__contents__child__body__info__2
+                .product-container-ruiweton__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-ruiweton__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
 
--#   .product-container-naigi
--#     %h3.product-container-naigi__title
--#       = link_to 'ナイギ 新着アイテム', root_path, class: 'product-container-naigi__title__link-btn'
--#     .product-container-naigi__contents
--#       .product-container-naigi__contents__child__body
--#         - @naigiitems.each do |item|
--#           = link_to "/items/#{item.id}" do
--#             .product-container-naigi__contents__child__body__image
--#               = image_tag (item.item_images.first.image.url), size: "213x213"
--#             .product-container-naigi__contents__child__body__info
--#               .product-container-naigi__contents__child__body__info__name
--#                 =item.name
--#               .product-container-naigi__contents__child__body__info__2
--#                 .product-container-naigi__contents__child__body__info__2__price
--#                   = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
--#                 .product-container-naigi__contents__child__body__info__2__iine
--#                   %i.fa.fa-heart
--#                     1
--#     .product-container__all
--#       = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'
+  .product-container-naigi
+    %h3.product-container-naigi__title
+      = link_to 'ナイギ 新着アイテム', root_path, class: 'product-container-naigi__title__link-btn'
+    .product-container-naigi__contents
+      .product-container-naigi__contents__child__body
+        - @naigiitems.each do |item|
+          = link_to "/items/#{item.id}" do
+            .product-container-naigi__contents__child__body__image
+              = image_tag (item.item_images.first.image.url), size: "213x213"
+            .product-container-naigi__contents__child__body__info
+              .product-container-naigi__contents__child__body__info__name
+                =item.name
+              .product-container-naigi__contents__child__body__info__2
+                .product-container-naigi__contents__child__body__info__2__price
+                  = number_to_currency(item.price, :unit => "¥ ", :precision => 0)
+                .product-container-naigi__contents__child__body__info__2__iine
+                  %i.fa.fa-heart
+                    1
+    .product-container__all
+      = link_to 'すべての商品を見る', root_path, class: 'items-box__container__all__button'

--- a/config/breadcrumbs.rb
+++ b/config/breadcrumbs.rb
@@ -3,7 +3,7 @@ crumb :root do
 end
 
 crumb :mypage do
-  link "マイページ", edit_top_path(1)
+  link "マイページ", edit_top_path(current_user)
   parent :root
 end
 
@@ -13,7 +13,7 @@ crumb :profile do
 end
 
 crumb :logout do
-  link "ログアウト", new_top_path
+  link "ログアウト", tops_path
   parent :mypage
 end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
   get 'mypage/profile' => 'users#profile'
   get 'mypage/identification' => 'users#identification'
   get 'mypage/card' => 'users#card'
+
   get 'signup' => 'users#signup'
   get 'logout' => 'users#logout'
   get 'sell' => 'items#sell'
@@ -19,10 +20,9 @@ Rails.application.routes.draw do
   get 'tops/edit' => 'tops#edit'
   
   resources :items do
-    collection do
+    member do
       post 'purchase'
-    end
-    collection do
+      get 'confirm'
       get 'complete'
     end
     collection do
@@ -30,7 +30,7 @@ Rails.application.routes.draw do
     end
     resources :comments, only: [:create]
   end
-  resources :tops, only: [:index, :new, :edit]
+  resources :tops, only: [:index, :edit]
   resources :users, only: [:index, :update]
 
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,6 +12,6 @@ CSV.foreach('db/categories.csv', headers: true) do |row|
   Category.create(id: row['id'], name: row['name'], parent_id: row['parent_id'], grandparent_id: row['grandparent_id'])
 end
 
-# CSV.foreach('db/brands.csv', headers: true) do |row|
-#   Brand.create(id: row['id'], created_at: row['created_at'], updated_at: row['updated_at'], name: row['name'])
-# end
+CSV.foreach('db/brands.csv', headers: true) do |row|
+  Brand.create(id: row['id'], created_at: row['created_at'], updated_at: row['updated_at'], name: row['name'])
+end


### PR DESCRIPTION
# WHAT
購入確認ページ・購入完了ページに商品のデータを正しく表示させる。
一連の購入の流れを適したパスでルートを指定する。

# WHY
今までの購入確認ページ・購入完了ページは固定の商品情報しか表示させていなかったので、きちんと出品されたそれぞれの商品が持つデータを画面に反映させるため。
パスを直すことによって、より分かりやすいルートにするため。