### PR TITLE
出品画面の修正（リンクの修正、商品名のバリデーションの文字数修正

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -9,15 +9,16 @@ class Item < ApplicationRecord
   accepts_nested_attributes_for :category
   accepts_nested_attributes_for :item_images
   validates_associated :item_images
-  validates :name, presence: true, length: { maximum: 75}
+  validates :name, presence: true, length: { maximum: 40}
   validates :detail, presence: true, length: { maximum: 1000}
   validates :condition, presence: true
   validates :delivery_cost, presence: true
   validates :delivery_prefecture, presence: true
   validates :days_to_ship, presence: true
   validates :delivery_method, presence: true
-  validates :price, presence: true, numericality:{less_than_or_equal_to:99999999, greater_than_or_equal_to:300}
+  validates :price, presence: true, numericality:{less_than_or_equal_to:9999999, greater_than_or_equal_to:300}
   validates :category_id, presence: true
+
 
   enum condition: {"新品、未使用": 1, "未使用に近い": 2, "目立った傷や汚れなし": 3, "やや傷や汚れあり": 4, "傷や汚れあり": 5, "全体的に状態が悪い": 6}
 

--- a/app/views/items/_product-sell.html.haml
+++ b/app/views/items/_product-sell.html.haml
@@ -134,9 +134,9 @@
                 =link_to '加盟店規約', "#", class:"notes__link"
                 に同意したことになります。
             = f.submit "出品する", class: "btn-sell btn-red", id: "product-sell-btn"
-            = link_to "もどる", "/mypage", class: "btn-sell btn-gray"
+            = link_to "もどる", :back, class: "btn-sell btn-gray"
           - else
             %div
             = f.submit "変更する", class: "btn-sell btn-red", id: "product-sell-btn"
             = link_to "キャンセル", item_path(@item.id), class: "btn-sell btn-gray"
-            
+          


### PR DESCRIPTION
# WHAT
出品画面に関する事象の修正
# WHY
1. 出品画面内の「戻る」ボタンのリンクを「:back」に変更（前ページに戻るようにした。）
2. 商品名の文字数制限を40文字に修正。
3. 価格の金額制限を99999999円⇨9999999円に修正