### PR TITLE
新規登録画面のcss修正

### DIFF
--- a/app/assets/javascripts/signup.js
+++ b/app/assets/javascripts/signup.js
@@ -14,7 +14,9 @@ pages.eq(0).fadeIn();
     var first_name = $('#first_name').val();
     var last_name_kana = $('#last_name_kana').val();
     var first_name_kana = $('#first_name_kana').val();
-    var birthday = $('#birthday').val();
+    var birthday_year = $('#user_profile_attributes_birthday_1i').val();
+    var birthday_month = $('#user_profile_attributes_birthday_2i').val();
+    var birthday_day = $('#user_profile_attributes_birthday_3i').val();
     if(nickname == "")
     {
       $('#error-nicnname').text("ニックネーム を入力してください");
@@ -70,7 +72,7 @@ pages.eq(0).fadeIn();
     {
       $('#error-first_name_kana1').text("名カナ はカナ文字を入力してください");
     };
-    if(birthday == "")
+    if(birthday_year == "" || birthday_month == "" || birthday_day == "")
     {
       $('#error-birth_date').text("生年月日を入力してください");
     };

--- a/app/assets/stylesheets/_nsignup.scss
+++ b/app/assets/stylesheets/_nsignup.scss
@@ -105,8 +105,9 @@
         color: #888;
       }
       .birthday_select{
-        width: 35%;
-        display: inline-block;
+        // width: 35%;
+        display: flex;
+        align-items: center;
         // &__wrap{
         //   width: 35%;
         //   display: inline-block;

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -120,7 +120,7 @@
                 .signup__forminfo
                   ="※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。"
               .signup__inner__group
-                -# = recaptcha_tags callback: 'recaptchaCallbackFunction'
+                = recaptcha_tags callback: 'recaptchaCallbackFunction'
 
               .signup__inner__group
                 .signup__notification

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -120,7 +120,7 @@
                 .signup__forminfo
                   ="※ 本人情報は正しく入力してください。会員登録後、修正するにはお時間を頂く場合があります。"
               .signup__inner__group
-                = recaptcha_tags callback: 'recaptchaCallbackFunction'
+                -# = recaptcha_tags callback: 'recaptchaCallbackFunction'
 
               .signup__inner__group
                 .signup__notification


### PR DESCRIPTION
# WHAT
新規登録画面の年月日のcssを修正する。
新規登録画面の年月日のjsを修正する。
# WHY
縦に並んでいたものを、横に並べる。
年月日が未入力だった場合、バリデーションのメッセージを表示する。
